### PR TITLE
Removed html height 100% as not needed by safari

### DIFF
--- a/static/styles/styles.less
+++ b/static/styles/styles.less
@@ -141,7 +141,7 @@ Desktop:
   // Flex elements will fill html/body space and scroll themselves
   html, body {
     width: 100%;
-    height: 100%;
+    // height: 100%; Not required - breaks safari
   }
 
   body {


### PR DESCRIPTION
Tested Chrome, FF, and Safari.

Was:

<img width="747" alt="safari" src="https://user-images.githubusercontent.com/381138/55113261-d8dc9b00-509b-11e9-9e5b-ebfbbeedf25c.png">

Is now:

<img width="1421" alt="Screen Shot 2019-03-27 at 2 23 57 PM" src="https://user-images.githubusercontent.com/381138/55113317-03c6ef00-509c-11e9-9ba2-0be395f1a611.png">
